### PR TITLE
Tickettwentyfour   #24 View User Profile Details

### DIFF
--- a/TabloidFullStack/TabloidFullStack/Controllers/UserProfileController.cs
+++ b/TabloidFullStack/TabloidFullStack/Controllers/UserProfileController.cs
@@ -29,6 +29,18 @@ namespace TabloidFullStack.Controllers
             return Ok(user);
         }
 
+        [HttpGet("GetById/{Id}")]
+        public IActionResult GetById(int Id)
+        {
+            var user = _userRepository.GetById(Id);
+
+            if ( user == null)
+            {
+                return NotFound();
+            }
+            return Ok(user);
+        }
+
         [HttpGet]
         public IActionResult Get()
         {

--- a/TabloidFullStack/TabloidFullStack/Repositories/IUserRepository.cs
+++ b/TabloidFullStack/TabloidFullStack/Repositories/IUserRepository.cs
@@ -10,5 +10,7 @@ namespace TabloidFullStack.Repositories
         //UserProfile GetAllProfiles();
 
         List<UserProfile> GetAllProfiles();
+
+        UserProfile GetById(int Id);
     }
 }

--- a/TabloidFullStack/TabloidFullStack/Repositories/UserRepository.cs
+++ b/TabloidFullStack/TabloidFullStack/Repositories/UserRepository.cs
@@ -102,6 +102,52 @@ namespace TabloidFullStack.Repositories
             }
         }
 
+        public UserProfile GetById(int Id)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        SELECT up.Id, up.FirstName, up.LastName, up.DisplayName, 
+                               up.Email, up.CreateDateTime, up.ImageLocation, up.UserTypeId,
+                               ut.Name AS UserTypeName
+                          FROM UserProfile up
+                               LEFT JOIN UserType ut on up.UserTypeId = ut.Id
+                         WHERE up.Id = @Id";
+
+                    DbUtils.AddParameter(cmd, "@Id", Id);
+
+                    UserProfile userProfile = null;
+
+                    var reader = cmd.ExecuteReader();
+                    if (reader.Read())
+                    {
+                        userProfile = new UserProfile()
+                        {
+                            Id = DbUtils.GetInt(reader, "Id"),
+                            FirstName = DbUtils.GetString(reader, "FirstName"),
+                            LastName = DbUtils.GetString(reader, "LastName"),
+                            DisplayName = DbUtils.GetString(reader, "DisplayName"),
+                            Email = DbUtils.GetString(reader, "Email"),
+                            CreateDateTime = DbUtils.GetDateTime(reader, "CreateDateTime"),
+                            ImageLocation = DbUtils.GetString(reader, "ImageLocation"),
+                            UserTypeId = DbUtils.GetInt(reader, "UserTypeId"),
+                            UserType = new UserType()
+                            {
+                                Id = DbUtils.GetInt(reader, "UserTypeId"),
+                                Name = DbUtils.GetString(reader, "UserTypeName"),
+                            }
+                        };
+                    }
+                    reader.Close();
+
+                    return userProfile;
+                }
+            }
+        }
+
         public void Add(UserProfile userProfile)
         {
             using (var conn = Connection)

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/Managers/UserProfileManager.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/Managers/UserProfileManager.js
@@ -42,6 +42,10 @@ export const getAllUserProfiles = () => {
     .then((res) => res.json());
 };
 
+export const getUserProfileById = (id) => {
+  return fetch(`${apiUrl}/api/userprofile/getById/${id}`)
+    .then((res) => res.json());
+};
 
 // return (
 //   <UserProfileContext.Provider value={{ isLoggedIn, login, logout, register,  }}>

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/ApplicationViews.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/ApplicationViews.js
@@ -9,6 +9,7 @@ import { CategoryList } from "./categories/CategoryList.js";
 import PostDetails from "./PostDetails.js";
 import { EditTag } from "./tags/EditTag.js";
 import UserProfileList from "./UserProfile/UserProfileList";
+import UserProfile from "./UserProfile/UserProfile.js";
 
 
 export default function ApplicationViews() {
@@ -24,6 +25,7 @@ export default function ApplicationViews() {
 			<Route path='/post/:id' element={<PostDetails />} />
 			<Route path='/Categories' element={<CategoryList />} />
 			{ user.userTypeId == 1? <Route path="/UserProfiles" element={<UserProfileList />} />:""}
+			{ user.userTypeId == 1? <Route path="/UserProfiles/:id" element={<UserProfile />} />:""}
 		</Routes>
 	);
 }

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/UserProfile.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/UserProfile.js
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from "react";
+import { getUserProfileById } from "../../Managers/UserProfileManager";
+import { useParams } from "react-router-dom";
+
+export default function UserProfile() {
+  const [userProfiles, setUserProfiles] = useState([]);
+
+  const { id } = useParams();
+
+  const dateFormat = new Date(userProfiles.createDateTime).toLocaleDateString('en-US');
+
+  useEffect(() => {
+    getUserProfileById(id).then(setUserProfiles);
+  }, []);
+
+  return (
+    <div>
+      <div>{userProfiles.fullName}</div>
+      <img src={userProfiles.imageLocation}/>
+      <div>{userProfiles.displayName}</div>
+      <div>{userProfiles.email}</div>
+      <div>{dateFormat}</div>
+      <div>{userProfiles?.userType?.name}</div>
+    </div>
+  );
+}

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/UserProfileList.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/UserProfile/UserProfileList.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { getAllUserProfiles } from "../../Managers/UserProfileManager";
+import { Link } from "react-router-dom";
 
 export default function UserProfileList() {
   const [userProfiles, setUserProfiles] = useState([]);
@@ -11,13 +12,19 @@ export default function UserProfileList() {
   return (
     <div>
       <h2>User Profiles</h2>
-      <ul>
+      <div>
         {userProfiles.map((user) => (
-          <li key={user.id}>
+          <>
+          <p key={user.id} className="row justify-content-center">
             {user.fullName} - {user.displayName} - {user.userType.name}
-          </li>
+          </p>
+          <div className="text-center">
+          <Link to={`/userprofiles/${user.id}`} className="text-center"> <button className="btn btn-primary">View Details</button> </Link>
+          </div>
+          <br />
+          </>
         ))}
-      </ul>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Added features of ticket 24 to user profiles feature.

testing and working on my end per instructions below

git add and git commit your branch
git checkout main
git fetch -a
git checkout tickettwentyfour
if you don't see the most recent version of my files git pull origin tickettwentyfour
if you have not created the database do so and follow steps below
Run sql scripts to create initial db.
Open TabloidFullstack.sln in Visual Studio
At the top of Visual Studio, select https as the launcher and click the green play button
The Swagger UI should appear in the browser
Confirm there is a PUT call under the Comment Controller in Swagger
If the React app isn't already running, in your terminal npm start otherwise refresh the React App
Once the app is up and running, login with foo@bar.com and no password
Select Posts
Click on the User Profile section, 
per ticket 24 the following should be viewable when View Details are chosen from the User Profiles tab

As an admin, I would like to see the content of a User Profile so I can read it.
Given a user is viewing a list of User Profiles
When they select a user
Then they should be directed to a User Profile Detail page

User Profile Details include:

Full name
Avatar image (if exists, else use a default image)
Display name
Email
Creation Date (MM/DD/YYYY)
User Profile type


Code follows guidelines of this project
Self review of my own code has been preformed
Commented code in hard to understand areas
My changes generate no new warnings or errors
I have added testing instructions that prove my feature is effective and works.